### PR TITLE
Added destroy method to tasks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,6 @@
   margin-left: 10px;
   padding: 0;
 }
+a.glyphicon {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -1,3 +1,14 @@
 // Place all the styles related to the tasks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.table-heading {
+  background: #000;
+  color: #fff;
+}
+.tasks-index {
+  padding-top: 20px;
+}
+.completed-tasks {
+  margin-top: -20px;
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,8 +1,19 @@
 // Place all the styles related to the users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-
-.table-heading {
-  background: #000;
-  color: #fff;
+.buttons {
+  padding-top: 20px;
+}
+.user-profile-info {
+}
+.user-profile-info ul {
+  padding-left: 0;
+  background-color: #f0f0f0;
+}
+.user-profile-info li {
+  list-style: none;
+}
+.avatar {
+  width: 70px;
+  vertical-align: bottom;
 }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,6 @@
 class TasksController < ApplicationController
   def new
     @task = Task.new
-    @user = User.find(session[:user_id])
   end
 
   def create
@@ -21,7 +20,6 @@ class TasksController < ApplicationController
   end
 
   def update
-    @user = User.find(session[:user_id])
     @task= Task.find(params[:id])
 
     if params[:task][:completed]
@@ -37,10 +35,22 @@ class TasksController < ApplicationController
 
     if @task.save
       flash[:notice] = "Task successfully #{attribute}."
-      # redirect_to user_path(@task)
     else
       flash[:alert] = "Something went wrong. Please try again."
-      # redirect_to user_path(@task)
+    end
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
+  end
+
+  def destroy
+    @task = Task.find(params[:id])
+    if @task.destroy
+      flash.now[:alert] = "You cannot delete this task. It's someone else property."
+    else
+      flash[:notice] = "Task permanently deleted."
     end
 
     respond_to do |format|

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,14 +26,13 @@ class TasksController < ApplicationController
 
     if params[:task][:completed]
       attribute = "completed"
-      @task.actual_end_date = Time.now
       @task.completed = params[:task][:completed]
+      @task.actual_end_date = Time.now
     end
     if params[:task][:deleted]
       attribute = "deleted"
       @task.update(deleted: params[:task][:deleted])
-      # I need this call to the database to set updated_at field at the time of deletion,
-      # because I use updated_at to calculate how many hours/days have passed from creation to deletion
+      @task.deletion_date = Time.now
     end
 
     if @task.save

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,8 +26,8 @@ class TasksController < ApplicationController
 
     if params[:task][:completed]
       attribute = "completed"
-      @task.completed = params[:task][:completed]
       @task.actual_end_date = Time.now
+      @task.completed = params[:task][:completed]
     end
     if params[:task][:deleted]
       attribute = "deleted"

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,4 +1,12 @@
 class TasksController < ApplicationController
+  def index
+    @user = User.find(session[:user_id])
+    @active_tasks = @user.tasks.active.order('expected_end_date ASC')
+    @completed_tasks = @user.tasks.completed.order("actual_end_date DESC")
+    @deleted_tasks = @user.tasks.deleted.order("updated_at DESC")
+    @uncompleted_tasks = @user.tasks.uncompleted
+  end
+
   def new
     @task = Task.new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(session[:user_id])
+    @tasks = @user.tasks
     @active_tasks = @user.tasks.active.order('expected_end_date ASC')
     @completed_tasks = @user.tasks.completed.order("actual_end_date DESC")
     @deleted_tasks = @user.tasks.deleted.order("updated_at DESC")

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -13,4 +13,16 @@ module TasksHelper
     time = (task.deletion_date - task.created_at)
     distance_of_time_in_words(time)
   end
+
+  def expiring_tasks_count(tasks, seconds)
+    total = []
+    tasks.each do |task|
+      limit = (Time.now.end_of_day.to_i + seconds)
+      if task.expected_end_date.to_i < limit || task.expected_end_date.end_of_day.to_i == limit
+        total << task
+      end
+    end
+    return total.count
+  end
+  
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -10,7 +10,7 @@ module TasksHelper
   end
 
   def deletion_time(task)
-    time = (task.updated_at - task.created_at)
+    time = (task.deletion_date - task.created_at)
     distance_of_time_in_words(time)
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,11 +1,11 @@
 module TasksHelper
   def time_left(task)
-    time = (task.expected_end_date.to_time.end_of_day - Time.now)
+    time = (task.expected_end_date.end_of_day - Time.now)
     distance_of_time_in_words(time)
   end
 
   def completion_time(task)
-    time = (task.actual_end_date.to_time - task.created_at)
+    time = (task.actual_end_date - task.created_at)
     distance_of_time_in_words(time)
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,10 +4,6 @@ class Task < ActiveRecord::Base
   validates :title, presence: true, length: { minimum: 3 }
   validates :expected_end_date, presence: true, if: :ends_after_now?
 
-  after_initialize { self.completed ||= false }
-  after_initialize { self.uncompleted ||= false }
-  after_initialize { self.deleted ||= false }
-
   scope :active, -> { where(:completed => false, :deleted => false, :uncompleted => false) }
   scope :completed, -> { where(completed: true) }
   scope :deleted, -> { where(deleted: true) }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   		<li><%= link_to "About", welcome_about_path %></li>
   		<div class="pull-right user-info">
         <% if current_user %>
-          <%= image_tag "#{current_user.image}", size: "48", alt: current_user.name %>
+          <%= image_tag "#{current_user.image}", size: "48", alt: "#{current_user.name} Google avatar" %>
           <div class="pull-right">
           	Signed in as <strong><%= link_to current_user.name, user_path(current_user), title: "Go to your profile page." %></strong>
             <br />

--- a/app/views/tasks/destroy.js.erb
+++ b/app/views/tasks/destroy.js.erb
@@ -1,0 +1,2 @@
+$('#task_<%= @task.id %>_table_row').fadeOut("slow");
+$('#task_<%= @task.id %>_ajax_row').fadeOut("slow");

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,91 @@
+<div class="row tasks-index">
+  <div class="col-md-8 completed-tasks">
+    <h1>Active tasks</h1>
+    <table class="table table-hover">
+      <tr class="">
+        <th>your task</th>
+        <th>time left</th>
+        <th colspan="3" style="text-align: center; color: #fff; background-color: #000;">possible actions</th>
+      </tr>
+      <% @active_tasks.each do |task| %>
+        <tr id="task_<%= task.id %>_table_row">
+          <td><%= task.title %></td>
+          <td><%= time_left(task) %></td>
+          <td>
+            <%= form_for task, remote: true do |t| %>
+              <%= t.hidden_field :completed, id: "task_#{task.id}_completed", value: "1" %>
+              <%= t.submit "completed", class: 'btn btn-success', title: "Mark this task as completed. Good job!" %>
+            <% end %>
+          </td>
+          <td>
+            <%= form_for task, remote: true do |t| %>
+              <%= t.hidden_field :deleted, id: "task_#{task.id}_deleted", value: "1" %>
+              <%= t.submit "delete", class: 'btn btn-warning', title: "Mark as deleted but still hold it in the database." %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to "erase", task, method: :delete, remote: true, class: 'btn btn-danger', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "The data of this task will be PERMANENTLY ERASED. Do you want to continue?" } %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+  <div class=col-md-4>
+    <%= link_to "New Task", new_task_path, class: 'btn btn-primary' %>
+    <%= link_to "Profile Page", user_path(@user), class: 'btn btn-success' %>
+    <br />
+    <h3>Completed tasks</h3>
+      <% if @completed_tasks == [] %>
+        <h5 id="no_completed_tasks" class="text-muted">You do not have completed tasks</h5>
+        <table id="completed_tasks_table" class="table">
+        </table>
+      <% else %>
+        <table class="table" id="completed_tasks_table">
+          <% @completed_tasks.limit(5).each do |task| %>
+            <tr id="task_<%= task.id %>_table_row">
+              <td class="text-muted"><%= task.title %></td>
+              <td class="text-muted">completed in <%= completion_time(task) %></td>
+              <td class="text-muted">
+                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      <% end %>
+
+    <h3>Deleted tasks</h3>
+      <% if @deleted_tasks == [] %>
+      <h5 id="no_deleted_tasks" class="text-muted">You do not have deleted tasks</h5>
+      <table id="deleted_tasks_table" class="table">
+      </table>
+      <% else %>
+        <table class="table" id="deleted_tasks_table">
+          <% @deleted_tasks.limit(5).each do |task| %>
+            <tr id="task_<%= task.id %>_table_row">
+              <td class="text-muted"><del><%= task.title %></del></td>
+              <td class="text-muted"><del>deleted after <%= deletion_time(task) %></del></td>
+              <td class="text-muted">
+                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      <% end %>
+
+    <h3>Incompleted tasks</h3>
+      <% if @uncompleted_tasks == [] %>
+        <h5 id="no_deleted_tasks" class="text-muted">You do not have incompleted tasks</h5>
+      <% else %>
+        <table id="incompleted_tasks_table" class="table">
+          <% @uncompleted_tasks.limit(5).each do |task| %>
+            <tr id="task_<%= task.id %>_table_row">
+              <td class="text-muted"><del><%= task.title %></del></td>
+              <td class="text-muted">
+                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
+              </td>
+            </tr>
+          <% end %>
+        </table>
+      <% end %>
+  </div>
+</div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -11,7 +11,7 @@
       </div>
       <div class="form-group">
         <%= f.label :expected_end_date %>
-        <%= f.text_field :expected_end_date, class: 'form-control', placeholder: "yyyy/mm/dd" %>
+        <%= f.datetime_field :expected_end_date, class: 'form-control', placeholder: "yyyy/mm/dd" %>
       </div>
       <div class="form-group">
         <%= f.submit "Submit", class: 'btn btn-success' %>

--- a/app/views/tasks/update.js.erb
+++ b/app/views/tasks/update.js.erb
@@ -1,13 +1,17 @@
 <% if params[:task][:completed] %>
-  $('#task_<%= @task.id %>_table_row').hide();
-  $('#no_completed_tasks').hide();
-  $('#completed_tasks_table').prepend("<tr id=\"task-<%= @task.id %>-ajax-row\"></tr>");
-  $('#task-<%= @task.id %>-ajax-row').html("<td class=\"text-muted\"><%= @task.title %></td><td class=\"text-muted\">completed in <%= completion_time(@task) %></td>");
+  $('#task_<%= @task.id %>_table_row').fadeOut("slow");
+  $('#no_completed_tasks').fadeOut();
+  $("<tr id=\"task_<%= @task.id %>_ajax_row\" class=\"bg-success\"></tr>").fadeIn(1600, function() {
+    var trashIcon = "<a class=\"glyphicon glyphicon-trash\" title=\"Attention: if you continue, this task will be PERMANENTLY ERASED from the database.\" data-confirm=\"!!!ATTENTION!!!\nThe data of &quot; <%= @task.title %> &quot; task will be PERMANENTLY ERASED.\nDo you want to continue?\" data-remote=\"true\" rel=\"nofollow\" data-method=\"delete\" href=\"/tasks/<%= @task.id %>\"></a>";
+    $(this).prependTo('#completed_tasks_table').html("<td class=\"text-muted\"><%= @task.title %></td><td class=\"text-muted\">completed in <%= completion_time(@task) %></td><td class=\"text-muted\">" + trashIcon + "</td>");
+  });
 <% end %>
 
 <% if params[:task][:deleted] %>
-  $('#task_<%= @task.id %>_table_row').hide();
-  $('#no_deleted_tasks').hide();
-  $('#deleted_tasks_table').prepend("<tr id=\"task-<%= @task.id %>-ajax-row\"></tr>");
-  $('#task-<%= @task.id %>-ajax-row').html("<td class=\"text-muted\"><del><%= @task.title %></del></td><td class=\"text-muted\"><del>deleted after <%= deletion_time(@task) %></del></td>");
+  $('#task_<%= @task.id %>_table_row').fadeOut("slow");
+  $('#no_deleted_tasks').fadeOut();
+  $("<tr id=\"task_<%= @task.id %>_ajax_row\" class=\"bg-danger\"></tr>").fadeIn(1600, function() {
+    var trashIcon = "<a class=\"glyphicon glyphicon-trash\" title=\"Attention: if you continue, this task will be PERMANENTLY ERASED from the database.\" data-confirm=\"!!!ATTENTION!!!\nThe data of &quot; <%= @task.title %> &quot; task will be PERMANENTLY ERASED.\nDo you want to continue?\" data-remote=\"true\" rel=\"nofollow\" data-method=\"delete\" href=\"/tasks/<%= @task.id %>\"></a>";
+    $(this).prependTo('#deleted_tasks_table').html("<td class=\"text-muted\"><del><%= @task.title %></del></td><td class=\"text-muted\"><del>deleted after <%= deletion_time(@task) %></del></td><td class=\"text-muted\">" + trashIcon + "</td>");
+  });
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,97 +1,29 @@
 <div class="row">
   <div class="col-md-8">
-    <h1>Welcome <span class="label label-success"><%= @user.name %></span> <small>active since: <%= @user.created_at.strftime("%B %d, %Y") %></small></h1>
+    <h1><%= @user.name %> <small>profile page</small></h1>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-4 buttons">
     <%= link_to "New Task", new_task_path, class: 'btn btn-primary' %>
+    <%= link_to "Tasks Page", tasks_path, class: 'btn btn-success' %>
   </div>
 </div>
 <br />
 <div class="row">
-  <div class="col-md-8">
-    <h1>Active tasks</h1>
-    <table class="table table-hover">
-      <tr class="">
-        <th>your task</th>
-        <th>time left</th>
-        <th colspan="3" style="text-align: center; color: #fff; background-color: #000;">possible actions</th>
-      </tr>
-      <% @active_tasks.each do |task| %>
-        <tr id="task_<%= task.id %>_table_row">
-          <td><%= task.title %></td>
-          <td><%= time_left(task) %></td>
-          <td>
-            <%= form_for task, remote: true do |t| %>
-              <%= t.hidden_field :completed, id: "task_#{task.id}_completed", value: "1" %>
-              <%= t.submit "completed", class: 'btn btn-success', title: "Mark this task as completed. Good job!" %>
-            <% end %>
-          </td>
-          <td>
-            <%= form_for task, remote: true do |t| %>
-              <%= t.hidden_field :deleted, id: "task_#{task.id}_deleted", value: "1" %>
-              <%= t.submit "delete", class: 'btn btn-warning', title: "Mark as deleted but still hold it in the database." %>
-            <% end %>
-          </td>
-          <td>
-            <%= link_to "erase", task, method: :delete, remote: true, class: 'btn btn-danger', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "The data of this task will be PERMANENTLY ERASED. Do you want to continue?" } %>
-          </td>
-        </tr>
-      <% end %>
-    </table>
+  <div class="user-profile-info col-md-6">
+    <h3>Tasks overview</h3>
+    <ul>
+      <li>Total tasks: <%= @tasks.count %></li>
+      <li>Completed Tasks: <%= @completed_tasks.count %></li>
+      <li>Deleted Tasks: <%= @deleted_tasks.count %></li>
+      <li>Incompleted Tasks: <%= @uncompleted_tasks.count %></li>
+    </ul>
   </div>
-  <div class=col-md-4>
-    <h3>Completed tasks</h3>
-      <% if @completed_tasks == [] %>
-        <h5 id="no_completed_tasks" class="text-muted">You do not have completed tasks</h5>
-        <table id="completed_tasks_table" class="table">
-        </table>
-      <% else %>
-        <table class="table" id="completed_tasks_table">
-          <% @completed_tasks.limit(5).each do |task| %>
-            <tr id="task_<%= task.id %>_table_row">
-              <td class="text-muted"><%= task.title %></td>
-              <td class="text-muted">completed in <%= completion_time(task) %></td>
-              <td class="text-muted">
-                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
-              </td>
-            </tr>
-          <% end %>
-        </table>
-      <% end %>
-
-    <h3>Deleted tasks</h3>
-      <% if @deleted_tasks == [] %>
-      <h5 id="no_deleted_tasks" class="text-muted">You do not have deleted tasks</h5>
-      <table id="deleted_tasks_table" class="table">
-      </table>
-      <% else %>
-        <table class="table" id="deleted_tasks_table">
-          <% @deleted_tasks.limit(5).each do |task| %>
-            <tr id="task_<%= task.id %>_table_row">
-              <td class="text-muted"><del><%= task.title %></del></td>
-              <td class="text-muted"><del>deleted after <%= deletion_time(task) %></del></td>
-              <td class="text-muted">
-                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
-              </td>
-            </tr>
-          <% end %>
-        </table>
-      <% end %>
-
-    <h3>Incompleted tasks</h3>
-      <% if @uncompleted_tasks == [] %>
-        <h5 id="no_deleted_tasks" class="text-muted">You do not have incompleted tasks</h5>
-      <% else %>
-        <table id="incompleted_tasks_table" class="table">
-          <% @uncompleted_tasks.limit(5).each do |task| %>
-            <tr id="task_<%= task.id %>_table_row">
-              <td class="text-muted"><del><%= task.title %></del></td>
-              <td class="text-muted">
-                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
-              </td>
-            </tr>
-          <% end %>
-        </table>
-      <% end %>
+  <div class="user-profile-info col-md-6">
+    <h3>You have <strong class="text-primary"><%= expiring_tasks_count(@active_tasks, 604800) %></strong> expiring tasks <small>(in one week)</small></h3>
+    <ul>
+      <li><span class="text-uppercase">To do by today</span>: <strong><%= today_tasks = expiring_tasks_count(@active_tasks, 0) %></strong></li>
+      <li><span class="text-uppercase">To do by tomorrow</span>: <strong><%= tomorrow_tasks = expiring_tasks_count(@active_tasks, 86400) - today_tasks %></strong></li>
+      <li><span class="text-uppercase">To do in one week</span>: <strong><%= expiring_tasks_count(@active_tasks, 604800) - tomorrow_tasks %></strong></li>
+    </ul>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,12 +10,11 @@
 <div class="row">
   <div class="col-md-8">
     <h1>Active tasks</h1>
-    <table class="table table-bordered table-hover">
-      <tr class="table-heading">
-        <th>title</th>
-        <th>expected end in</th>
-        <th></th>
-        <th></th>
+    <table class="table table-hover">
+      <tr class="">
+        <th>your task</th>
+        <th>time left</th>
+        <th colspan="3" style="text-align: center; color: #fff; background-color: #000;">possible actions</th>
       </tr>
       <% @active_tasks.each do |task| %>
         <tr id="task_<%= task.id %>_table_row">
@@ -24,14 +23,17 @@
           <td>
             <%= form_for task, remote: true do |t| %>
               <%= t.hidden_field :completed, id: "task_#{task.id}_completed", value: "1" %>
-              <%= t.submit "completed", class: 'btn btn-success' %>
+              <%= t.submit "completed", class: 'btn btn-success', title: "Mark this task as completed. Good job!" %>
             <% end %>
           </td>
           <td>
             <%= form_for task, remote: true do |t| %>
               <%= t.hidden_field :deleted, id: "task_#{task.id}_deleted", value: "1" %>
-              <%= t.submit "delete", class: 'btn btn-danger' %>
+              <%= t.submit "delete", class: 'btn btn-warning', title: "Mark as deleted but still hold it in the database." %>
             <% end %>
+          </td>
+          <td>
+            <%= link_to "erase", task, method: :delete, remote: true, class: 'btn btn-danger', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "The data of this task will be PERMANENTLY ERASED. Do you want to continue?" } %>
           </td>
         </tr>
       <% end %>
@@ -46,9 +48,12 @@
       <% else %>
         <table class="table" id="completed_tasks_table">
           <% @completed_tasks.limit(5).each do |task| %>
-            <tr>
+            <tr id="task_<%= task.id %>_table_row">
               <td class="text-muted"><%= task.title %></td>
               <td class="text-muted">completed in <%= completion_time(task) %></td>
+              <td class="text-muted">
+                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
+              </td>
             </tr>
           <% end %>
         </table>
@@ -62,9 +67,12 @@
       <% else %>
         <table class="table" id="deleted_tasks_table">
           <% @deleted_tasks.limit(5).each do |task| %>
-            <tr>
+            <tr id="task_<%= task.id %>_table_row">
               <td class="text-muted"><del><%= task.title %></del></td>
               <td class="text-muted"><del>deleted after <%= deletion_time(task) %></del></td>
+              <td class="text-muted">
+                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
+              </td>
             </tr>
           <% end %>
         </table>
@@ -76,8 +84,11 @@
       <% else %>
         <table id="incompleted_tasks_table" class="table">
           <% @uncompleted_tasks.limit(5).each do |task| %>
-            <tr>
+            <tr id="task_<%= task.id %>_table_row">
               <td class="text-muted"><del><%= task.title %></del></td>
+              <td class="text-muted">
+                <%= link_to "", task, method: :delete, remote: true, class: 'glyphicon glyphicon-trash', title: "Attention: if you continue, this task will be PERMANENTLY ERASED from the database.", data: { confirm: "ATTENTION!!\nThe data of \"#{task.title}\" task will be PERMANENTLY ERASED.\nDo you want to continue?" } %>
+              </td>
             </tr>
           <% end %>
         </table>

--- a/db/migrate/20160511232718_change_tasks_date_fields_column_type.rb
+++ b/db/migrate/20160511232718_change_tasks_date_fields_column_type.rb
@@ -1,8 +1,0 @@
-class ChangeTasksDateFieldsColumnType < ActiveRecord::Migration
-  def change
-    change_table :tasks do |t|
-      t.change :expected_end_date, :datetime
-      t.change :actual_end_date, :datetime
-    end
-  end
-end

--- a/db/migrate/20160511232718_change_tasks_date_fields_column_type.rb
+++ b/db/migrate/20160511232718_change_tasks_date_fields_column_type.rb
@@ -1,0 +1,8 @@
+class ChangeTasksDateFieldsColumnType < ActiveRecord::Migration
+  def change
+    change_table :tasks do |t|
+      t.change :expected_end_date, :datetime
+      t.change :actual_end_date, :datetime
+    end
+  end
+end

--- a/db/migrate/20160512003811_add_column_deletion_date_to_tasks.rb
+++ b/db/migrate/20160512003811_add_column_deletion_date_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddColumnDeletionDateToTasks < ActiveRecord::Migration
+  def change
+    add_column :tasks, :deletion_date, :datetime
+  end
+end

--- a/db/migrate/20160518152553_fix_tasks_expected_end_date.rb
+++ b/db/migrate/20160518152553_fix_tasks_expected_end_date.rb
@@ -1,0 +1,6 @@
+class FixTasksExpectedEndDate < ActiveRecord::Migration
+  def change
+    remove_column :tasks, :expected_end_date
+    add_column :tasks, :expected_end_date, :datetime
+  end
+end

--- a/db/migrate/20160518152925_fix_tasks_actual_end_date.rb
+++ b/db/migrate/20160518152925_fix_tasks_actual_end_date.rb
@@ -1,0 +1,6 @@
+class FixTasksActualEndDate < ActiveRecord::Migration
+  def change
+    remove_column :tasks, :actual_end_date
+    add_column :tasks, :actual_end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160512003811) do
+ActiveRecord::Schema.define(version: 20160518152925) do
 
   create_table "tasks", force: :cascade do |t|
-    t.string   "title",             null: false
+    t.string   "title",                             null: false
     t.text     "notes"
-    t.datetime "expected_end_date", null: false
     t.boolean  "completed",         default: false
-    t.datetime "actual_end_date"
     t.boolean  "deleted",           default: false
     t.datetime "deletion_date"
     t.boolean  "uncompleted",       default: false
     t.integer  "user_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.datetime "expected_end_date"
+    t.datetime "actual_end_date"
   end
 
   add_index "tasks", ["user_id"], name: "index_tasks_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,9 +18,9 @@ ActiveRecord::Schema.define(version: 20160505211504) do
     t.text     "notes"
     t.string   "expected_end_date", null: false
     t.string   "actual_end_date"
-    t.boolean  "completed"
-    t.boolean  "uncompleted"
-    t.boolean  "deleted"
+    t.boolean  "completed", default: false
+    t.boolean  "uncompleted", default: false
+    t.boolean  "deleted", default: false
     t.integer  "user_id"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,19 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160505211504) do
+ActiveRecord::Schema.define(version: 20160511232718) do
 
   create_table "tasks", force: :cascade do |t|
-    t.string   "title",             null: false
+    t.string   "title",                             null: false
     t.text     "notes"
-    t.string   "expected_end_date", null: false
-    t.string   "actual_end_date"
-    t.boolean  "completed", default: false
-    t.boolean  "uncompleted", default: false
-    t.boolean  "deleted", default: false
+    t.datetime "expected_end_date",                 null: false
+    t.datetime "actual_end_date"
+    t.boolean  "completed",         default: false
+    t.boolean  "uncompleted",       default: false
+    t.boolean  "deleted",           default: false
     t.integer  "user_id"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
   end
 
   add_index "tasks", ["user_id"], name: "index_tasks_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,19 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160511232718) do
+ActiveRecord::Schema.define(version: 20160512003811) do
 
   create_table "tasks", force: :cascade do |t|
-    t.string   "title",                             null: false
+    t.string   "title",             null: false
     t.text     "notes"
-    t.datetime "expected_end_date",                 null: false
-    t.datetime "actual_end_date"
+    t.datetime "expected_end_date", null: false
     t.boolean  "completed",         default: false
-    t.boolean  "uncompleted",       default: false
+    t.datetime "actual_end_date"
     t.boolean  "deleted",           default: false
+    t.datetime "deletion_date"
+    t.boolean  "uncompleted",       default: false
     t.integer  "user_id"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
   end
 
   add_index "tasks", ["user_id"], name: "index_tasks_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@
   task = Task.create!(
     title: Faker::Lorem::sentence,
     created_at: Faker::Time.between(DateTime.now - 30, DateTime.now - 1),
-    expected_end_date: Faker::Time.between(DateTime.now.end_of_day, DateTime.now + 30),
+    expected_end_date: Faker::Time.between(DateTime.now, DateTime.now + 30),
     user_id: "1",
   )
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,12 +6,21 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-50.times do
+25.times do
   task = Task.create!(
     title: Faker::Lorem::sentence,
     created_at: Faker::Time.between(DateTime.now - 30, DateTime.now - 1),
     expected_end_date: Faker::Time.between(DateTime.now, DateTime.now + 30),
     user_id: "1",
+  )
+end
+
+25.times do
+  task = Task.create!(
+    title: Faker::Lorem::sentence,
+    created_at: Faker::Time.between(DateTime.now - 30, DateTime.now - 1),
+    expected_end_date: Faker::Time.between(DateTime.now, DateTime.now + 30),
+    user_id: "2",
   )
 end
 
@@ -21,6 +30,15 @@ end
     created_at: Faker::Time.between(DateTime.now - 30, DateTime.now - 20),
     expected_end_date: Faker::Time.between(DateTime.now - 21, DateTime.now - 10),
     user_id: "1",
+  )
+end
+
+5.times do
+  task = Task.create!(
+    title: Faker::Lorem::sentence,
+    created_at: Faker::Time.between(DateTime.now - 30, DateTime.now - 20),
+    expected_end_date: Faker::Time.between(DateTime.now - 21, DateTime.now - 10),
+    user_id: "2",
   )
 end
 

--- a/lib/tasks/incompleted_tasks.rake
+++ b/lib/tasks/incompleted_tasks.rake
@@ -1,8 +1,7 @@
 namespace :older_tasks do
-  desc "Delete tasks when they reach their expected end date"
+  desc "Mark tasks as incomplete when they reach their expected end date"
   task mark_as_incomplete: :environment do
-    _tasks = Task.active
-    _tasks.each do |t|
+    Task.active.each do |t|
       if t.expected_end_date.to_time.end_of_day <= DateTime.now
         t.update(uncompleted: true)
       end


### PR DESCRIPTION
I added destroy function to tasks controller and refactored ajax functionality so that it is possibile to mark tasks as completed or deleted or permanently erase them from the database asyncronously or reloading the page.

Please, take a look at `app/views/tasks/update.js.erb`. I wanted to add a `fadeOut/ fadeIn` effect when tasks are marked as completed or deleted (`fadeOut` from the main list and `fadeIn` into the corresponding side list).
`fadeOut` is ok, but the `fadeIn` part doesn't behave like I expected: it take some time to appear (and that's what I wanted) but then it appears all of a sudden instead of fading in.

![tasks destroy](https://cloud.githubusercontent.com/assets/15610747/15342771/3b527f06-1c98-11e6-8142-5d2404c0b9dc.png)

Today I refactored `users#show` view to display some informations about user's tasks and added `tasks#index` view as you suggested last week.

The style of `users#show` is awful; I'll take care of it in the future.

I'm going to deploy to heroku in the afternoon, so you can test it.

![users show](https://cloud.githubusercontent.com/assets/15610747/15356858/980b8dc4-1cfb-11e6-9ee6-2a112a833447.png)

![tasks index](https://cloud.githubusercontent.com/assets/15610747/15356861/9d70dd46-1cfb-11e6-90e7-5f78b8c8ff1c.png)
